### PR TITLE
Move non-resource related alarms from system to misc

### DIFF
--- a/tasks/misc_services.yml
+++ b/tasks/misc_services.yml
@@ -26,22 +26,35 @@
     undetermined_actions:
       - "{{ default_notification.notification_method_id | default(omit) }}"
   with_items:
+    - { name: "HTTP Status",
+        description: "Alarms when the specified HTTP endpoint is down or not reachable",
+        severity: "HIGH",
+        expression: "http_status > 0",
+        match_by: ["service", "component", "hostname", "url"] }
+    - { name: "Process Check",
+        description: "Alarms when the specified process is not running",
+        severity: "HIGH",
+        expression: "process.pid_count < 1",
+        match_by: ["process_name", "hostname"] }
+    - { name: "Kernel Crash Dumps",
+        description: "Kernel crash dumps are available on disk",
+        expression: "crash.dump_count > 1" }
     - { name: "RabbitMQ Queue Depth",
         description: "Alarms when the depth of the message queue is high",
         expression: "avg(rabbitmq.queue.messages) > 10 times 3",
         severity: "MEDIUM",
-        match_by: [queue, hostname]}
+        match_by: ["queue", "hostname"] }
     - { name: "MySQL Slow Query Rate",
         description: "Alarms when the slow query rate is high",
-        expression: "avg(mysql.performance.slow_queries) > 10 times 3"}
+        expression: "avg(mysql.performance.slow_queries) > 10 times 3" }
     - { name: "Apache Status",
         description: "Alarms on failure to reach the Apache status endpoint",
         expression: "apache.status > 0",
-        severity: "HIGH"}
+        severity: "HIGH" }
     - { name: "Apache Idle Worker Count",
         description: "Alarms when there are no idle workers in the Apache server",
         expression: "avg(apache.performance.idle_worker_count) < 1 times 3",
-        severity: "MEDIUM"}
+        severity: "MEDIUM" }
     - { name: "NTP Time Sync",
         description: "Alarms when the NTP time offset is high",
-        expression: "ntp.offset > 5 or ntp.offset < -5"}
+        expression: "ntp.offset > 5 or ntp.offset < -5" }

--- a/tasks/system.yml
+++ b/tasks/system.yml
@@ -30,34 +30,25 @@
         description: "Alarms when the specified host is down or not reachable",
         severity: "HIGH",
         expression: "host_alive_status > 0" }
-    - { name: "HTTP Status",
-        description: "Alarms when the specified HTTP endpoint is down or not reachable",
-        severity: "HIGH",
-        expression: "http_status > 0",
-        match_by: ["service", "component", "hostname", "url"] }
     - { name: "CPU Usage",
         description: "Alarms when CPU usage is high",
+        severity: "MEDIUM",
         expression: "avg(cpu.idle_perc) < 10 times 3" }
     - { name: "Disk Inode Usage",
         description: "Alarms when disk inode usage is high",
+        severity: "MEDIUM",
         expression: "disk.inode_used_perc > 90",
         match_by: ["hostname", "device"] }
     - { name: "Disk Usage",
         description: "Alarms when disk usage is high",
+        severity: "MEDIUM",
         expression: "disk.space_used_perc > 90",
         match_by: ["hostname", "device"] }
     - { name: "Memory Usage",
         description: "Alarms when memory usage is high",
         severity: "MEDIUM",
         expression: "avg(mem.usable_perc) < 10 times 3" }
-    - { name: "Kernel Crash Dumps",
-        description: "Kernel crash dumps are available on disk",
-        expression: "crash.dump_count > 1" }
     - { name: "Network Errors",
         description: "Alarms when either incoming or outgoing network errors are high",
-        severity: "MEDIUM", expression: "net.in_errors_sec > 5 or net.out_errors_sec > 5" }
-    - { name: "Process Check",
-        description: "Alarms when the specified process is not running",
-        severity: "HIGH",
-        expression: "process.pid_count < 1",
-        match_by: ["process_name", "hostname"] }
+        severity: "MEDIUM",
+        expression: "net.in_errors_sec > 5 or net.out_errors_sec > 5" }


### PR DESCRIPTION
Moves 'HTTP Status', 'Kernel Crash Dumps' & 'Process Check' alarms to misc_services task file - this leaves the system file concerned with host resources only. 
Upgrades the severity of some resource alarms from low to medium.
Minor aesthetic syntax changes.